### PR TITLE
Fix where can I find documentation URL

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ The WordPress support forums: https://wordpress.org/support/plugin/wp-chosen/
 
 = Where can I find documentation? =
 
-http://github.com/stuttter/wp-chosen/
+http://github.com/johnjamesjacoby/wp-chosen/
 
 == Changelog ==
 


### PR DESCRIPTION
Documentation URL http://github.com/stuttter/wp-chosen/ was 404. Assuming it was meant to point to the repository here.