### PR TITLE
Add timeout to account for slidedown in submitdiv

### DIFF
--- a/wp-chosen/assets/js/wp-chosen.js
+++ b/wp-chosen/assets/js/wp-chosen.js
@@ -37,10 +37,13 @@ jQuery( document ).ready( function ( $ ) {
 
 	/* Special case the "Publish" meta box "Edit" links */
 	$( '.misc-pub-section a' ).on( 'click', function() {
-		$( this ).next( 'div, fieldset' )
-			.find( 'select' )
-				.chosen( 'destroy' )
-				.chosen( chosen_options );
+		var $this = $( this );
+		setTimeout( function() {
+			$this.next( 'div, fieldset' )
+				.find( 'select' )
+					.chosen( 'destroy' )
+					.chosen( chosen_options );
+		}, 250);
 	} );
 
 	/* Special case the "Publish" meta box "Edit" links */


### PR DESCRIPTION
fixes #9

`slideDown( 'fast')` in wp-admin/js/post.js#658 takes 200ms, until then select box is not visible and chosen will get width of 0px; setting a timeout on chosen to fire later prevents this